### PR TITLE
Remove the need for most `Object` clones

### DIFF
--- a/lib/evaluator/environment.rs
+++ b/lib/evaluator/environment.rs
@@ -44,8 +44,7 @@ impl Environment {
         }
     }
 
-    pub fn set(&mut self, name: &str, val: &Object) {
-        let val = val.clone();
+    pub fn set(&mut self, name: &str, val: Object) {
         self.store.insert(name.to_string(), val);
     }
 

--- a/lib/evaluator/object.rs
+++ b/lib/evaluator/object.rs
@@ -27,10 +27,10 @@ impl Object {
         matches!(*self, Object::ReturnValue(_))
     }
 
-    pub fn returned(&self) -> Self {
-        match *self {
-            Object::ReturnValue(ref o) => *o.clone(),
-            ref o => o.clone(),
+    pub fn returned(self) -> Self {
+        match self {
+            Object::ReturnValue(o) => *o,
+            o => o,
         }
     }
 }

--- a/lib/parser/mod.rs
+++ b/lib/parser/mod.rs
@@ -2,6 +2,7 @@ use nom::*;
 
 pub mod ast;
 use crate::lexer::token::*;
+use crate::parser::ast::*;
 use nom::branch::*;
 use nom::bytes::complete::take;
 use nom::combinator::{map, opt, verify};
@@ -9,7 +10,6 @@ use nom::error::{Error, ErrorKind};
 use nom::multi::many0;
 use nom::sequence::*;
 use nom::Err;
-use crate::parser::ast::*;
 use std::result::Result::*;
 
 macro_rules! tag_token (
@@ -217,8 +217,8 @@ fn go_parse_pratt_expr(input: Tokens, precedence: Precedence, left: Expr) -> IRe
     if t1.tok.is_empty() {
         Ok((i1, left))
     } else {
-        let preview = t1.tok[0].clone();
-        let p = infix_op(&preview);
+        let preview = &t1.tok[0];
+        let p = infix_op(preview);
         match p {
             (Precedence::PCall, _) if precedence < Precedence::PCall => {
                 let (i2, left2) = parse_call_expr(input, left)?;
@@ -242,8 +242,8 @@ fn parse_infix_expr(input: Tokens, left: Expr) -> IResult<Tokens, Expr> {
     if t1.tok.is_empty() {
         Err(Err::Error(error_position!(input, ErrorKind::Tag)))
     } else {
-        let next = t1.tok[0].clone();
-        let (precedence, maybe_op) = infix_op(&next);
+        let next = &t1.tok[0];
+        let (precedence, maybe_op) = infix_op(next);
         match maybe_op {
             None => Err(Err::Error(error_position!(input, ErrorKind::Tag))),
             Some(op) => {

--- a/repl/main.rs
+++ b/repl/main.rs
@@ -131,7 +131,7 @@ fn main() -> rustyline::Result<()> {
                         let parsed = Parser::parse_tokens(tokens);
                         match parsed {
                             Ok((_, program)) => {
-                                let eval = evaluator.eval_program(&program);
+                                let eval = evaluator.eval_program(program);
                                 println!("{}", eval);
                             }
                             Err(Err::Error(_)) => println!("Parser error"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
                 let parsed = Parser::parse_tokens(tokens);
                 match parsed {
                     Ok((_, program)) => {
-                        let eval = evaluator.eval_program(&program);
+                        let eval = evaluator.eval_program(program);
                         println!("{}", eval);
                     }
                     Err(Err::Error(_)) => println!("Parser error"),

--- a/tests/monkey_test.rs
+++ b/tests/monkey_test.rs
@@ -22,7 +22,7 @@ fn test_example_hash() {
     let (_, lex_tokens) = Lexer::lex_tokens(code_string.as_bytes()).unwrap();
     let tokens = Tokens::new(&lex_tokens);
     let (_, program) = Parser::parse_tokens(tokens).unwrap();
-    let eval = evaluator.eval_program(&program);
+    let eval = evaluator.eval_program(program);
     assert_eq!(eval, Object::Null);
 }
 
@@ -33,6 +33,6 @@ fn test_reduce() {
     let (_, lex_tokens) = Lexer::lex_tokens(code_string.as_bytes()).unwrap();
     let tokens = Tokens::new(&lex_tokens);
     let (_, program) = Parser::parse_tokens(tokens).unwrap();
-    let eval = evaluator.eval_program(&program);
+    let eval = evaluator.eval_program(program);
     assert_eq!(eval, Object::Null);
 }


### PR DESCRIPTION
Making `eval`-type functions take ownership of objects allows to consume them without having to clone them.

This design change simply pushes a potential cloning requirement back, at the level of the caller to `eval_program`. 
most programs will probably only get evaluated once so this change should improve performance in the majority of use cases :)

side note: while refactoring I noticed that there is a lot of left to right consuming of collections (and left insertion for `bcons`), for which `Vec`s theoretically aren't that good at (`remove(0)`/`insert(0, …)` can be a bit costly). I wonder if a `VecDeque` would be better and/or if there would be a way to refactor most of those cases to accept Iterables instead. 
I guess setting up benchmarks would probably be wiser to do before working on that though.